### PR TITLE
バイオームでの感染ブロック生成処理を削除

### DIFF
--- a/src/main/java/me/enchan/ExterminatorMod.java
+++ b/src/main/java/me/enchan/ExterminatorMod.java
@@ -1,0 +1,15 @@
+package me.enchan;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.fabricmc.api.ModInitializer;
+
+public class ExterminatorMod implements ModInitializer {
+    public static final Logger Logger = LoggerFactory.getLogger("exterminator");
+
+    @Override
+    public void onInitialize() {
+        Logger.info("Hello Fabric world!");
+    }
+}

--- a/src/main/java/me/enchan/ExterminatorMod.java
+++ b/src/main/java/me/enchan/ExterminatorMod.java
@@ -13,7 +13,9 @@ import net.minecraft.util.Identifier;
 import net.minecraft.world.gen.feature.PlacedFeature;
 
 public class ExterminatorMod implements ModInitializer {
-    public static final Logger Logger = LoggerFactory.getLogger("exterminator");
+    public static final String ModId = "exterminator";
+
+    public static final Logger Logger = LoggerFactory.getLogger(ModId);
 
     private static final RegistryKey<PlacedFeature> infestedOreFeatureKey = RegistryKey.of(RegistryKeys.PLACED_FEATURE,
             Identifier.of("minecraft", "ore_infested"));
@@ -21,7 +23,7 @@ public class ExterminatorMod implements ModInitializer {
     @Override
     public void onInitialize() {
         // ore_infested をバイオームフィーチャから削除する
-        BiomeModifications.create(Identifier.of("exterminator", "remove_infested_ore")).add(ModificationPhase.REMOVALS,
+        BiomeModifications.create(Identifier.of(ModId, "remove_infested_ore")).add(ModificationPhase.REMOVALS,
                 BiomeSelectors.all(),
                 ctx -> ctx.getGenerationSettings().removeFeature(infestedOreFeatureKey));
     }

--- a/src/main/java/me/enchan/ExterminatorMod.java
+++ b/src/main/java/me/enchan/ExterminatorMod.java
@@ -4,12 +4,25 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
+import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
+import net.fabricmc.fabric.api.biome.v1.ModificationPhase;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.gen.feature.PlacedFeature;
 
 public class ExterminatorMod implements ModInitializer {
     public static final Logger Logger = LoggerFactory.getLogger("exterminator");
 
+    private static final RegistryKey<PlacedFeature> infestedOreFeatureKey = RegistryKey.of(RegistryKeys.PLACED_FEATURE,
+            Identifier.of("minecraft", "ore_infested"));
+
     @Override
     public void onInitialize() {
-        Logger.info("Hello Fabric world!");
+        // ore_infested をバイオームフィーチャから削除する
+        BiomeModifications.create(Identifier.of("exterminator", "remove_infested_ore")).add(ModificationPhase.REMOVALS,
+                BiomeSelectors.all(),
+                ctx -> ctx.getGenerationSettings().removeFeature(infestedOreFeatureKey));
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -13,7 +13,11 @@
 	"license": "MIT",
 	"icon": "assets/exterminator/icon.png",
 	"environment": "*",
-	"entrypoints": {},
+	"entrypoints": {
+		"main": [
+			"me.enchan.ExterminatorMod"
+		]
+	},
 	"mixins": [
 		"exterminator.mixins.json"
 	],


### PR DESCRIPTION
Fixes: #2

`BiomeModification` により、フィーチャ `ore_infested` が生成されないようにしました。

- **feat: #2 MODエントリポイントを追加**
- **feat: #2 全バイオームから ore_infested feature を削除**
- **chore: add ID definition of MOD**
