### PR TITLE
構造物の感染ブロック生成処理を阻止した

### DIFF
--- a/src/main/java/me/enchan/ExterminatorMod.java
+++ b/src/main/java/me/enchan/ExterminatorMod.java
@@ -3,6 +3,7 @@ package me.enchan;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import me.enchan.processors.ExterminatorModProcessors;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
 import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
@@ -22,6 +23,9 @@ public class ExterminatorMod implements ModInitializer {
 
     @Override
     public void onInitialize() {
+        // カスタムプロセッサを登録する
+        ExterminatorModProcessors.initialize();
+
         // ore_infested をバイオームフィーチャから削除する
         BiomeModifications.create(Identifier.of(ModId, "remove_infested_ore")).add(ModificationPhase.REMOVALS,
                 BiomeSelectors.all(),

--- a/src/main/java/me/enchan/mixin/FirstFloorRoomPoolMixin.java
+++ b/src/main/java/me/enchan/mixin/FirstFloorRoomPoolMixin.java
@@ -1,0 +1,18 @@
+package me.enchan.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import me.enchan.ExterminatorMod;
+import net.minecraft.util.math.random.Random;
+
+@Mixin(targets = "net.minecraft.structure.WoodlandMansionGenerator$FirstFloorRoomPool")
+public abstract class FirstFloorRoomPoolMixin {
+    @Inject(method = "getMediumSecretRoom", at = @At("RETURN"), cancellable = true)
+    public void onGetMediumSecretRoom(Random random, CallbackInfoReturnable<String> cir) {
+        ExterminatorMod.Logger.info("構造物消毒: 森の洋館 偽エンドポータル部屋の生成を抑止しました");
+        cir.setReturnValue("1x2_s1");
+    }
+}

--- a/src/main/java/me/enchan/mixin/IglooGeneratorPieceMixin.java
+++ b/src/main/java/me/enchan/mixin/IglooGeneratorPieceMixin.java
@@ -1,0 +1,30 @@
+package me.enchan.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import me.enchan.processors.DisinfectionProcessor;
+import net.minecraft.structure.IglooGenerator;
+import net.minecraft.structure.StructurePlacementData;
+import net.minecraft.util.BlockRotation;
+import net.minecraft.util.Identifier;
+
+@Mixin(IglooGenerator.Piece.class)
+public abstract class IglooGeneratorPieceMixin {
+    @Inject(method = "createPlacementData", at = @At("RETURN"), cancellable = true)
+    private static void onCreatePlacementData(
+            BlockRotation rotation,
+            Identifier identifier,
+            CallbackInfoReturnable<StructurePlacementData> cir) {
+        if (!identifier.getPath().equals("igloo/bottom")) {
+            return;
+        }
+
+        // 地下室に消毒Processorを追加
+        var data = cir.getReturnValue();
+        data.addProcessor(DisinfectionProcessor.INSTANCE);
+        cir.setReturnValue(data);
+    }
+}

--- a/src/main/java/me/enchan/mixin/WoodlandMansionGeneratorPieceMixin.java
+++ b/src/main/java/me/enchan/mixin/WoodlandMansionGeneratorPieceMixin.java
@@ -1,0 +1,29 @@
+package me.enchan.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import me.enchan.processors.DisinfectionProcessor;
+import net.minecraft.structure.StructurePlacementData;
+import net.minecraft.structure.WoodlandMansionGenerator;
+import net.minecraft.util.BlockMirror;
+import net.minecraft.util.BlockRotation;
+
+@Mixin(WoodlandMansionGenerator.Piece.class)
+public abstract class WoodlandMansionGeneratorPieceMixin {
+    @Inject(method = "createPlacementData", at = @At("RETURN"), cancellable = true)
+    private static void onCreatePlacementData(
+            BlockMirror mirror, BlockRotation rotation,
+            CallbackInfoReturnable<StructurePlacementData> cir) {
+
+        // NOTE: 1.20.6 時点で、森の洋館に生成されるパーツのうち消毒が必要なブロックは 1x2_s2 のみ。
+        // NOTE: ただし、これ以外に存在した場合に消毒漏れが発生すると大変なので、Processorも割り当てる
+
+        // 消毒Processorを追加
+        var data = cir.getReturnValue();
+        data.addProcessor(DisinfectionProcessor.INSTANCE);
+        cir.setReturnValue(data);
+    }
+}

--- a/src/main/java/me/enchan/processors/DisinfectionProcessor.java
+++ b/src/main/java/me/enchan/processors/DisinfectionProcessor.java
@@ -1,0 +1,43 @@
+package me.enchan.processors;
+
+import com.mojang.serialization.MapCodec;
+
+import net.minecraft.block.InfestedBlock;
+import net.minecraft.structure.StructurePlacementData;
+import net.minecraft.structure.StructureTemplate;
+import net.minecraft.structure.StructureTemplate.StructureBlockInfo;
+import net.minecraft.structure.processor.StructureProcessor;
+import net.minecraft.structure.processor.StructureProcessorType;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.WorldView;
+
+public class DisinfectionProcessor extends StructureProcessor {
+    public static final DisinfectionProcessor INSTANCE = new DisinfectionProcessor();
+
+    public static final MapCodec<DisinfectionProcessor> CODEC = MapCodec.unit(INSTANCE);
+
+    @Override
+    public StructureBlockInfo process(
+            WorldView world,
+            BlockPos pos,
+            BlockPos pivot,
+            StructureBlockInfo originalBlockInfo,
+            StructureBlockInfo currentBlockInfo,
+            StructurePlacementData data) {
+        var state = currentBlockInfo.state();
+        var block = state.getBlock();
+
+        if (!(block instanceof InfestedBlock)) {
+            return currentBlockInfo;
+        }
+
+        // 感染ブロックを通常ブロックに戻す
+        var disinfected = ((InfestedBlock) block).toRegularState(state);
+        return new StructureTemplate.StructureBlockInfo(currentBlockInfo.pos(), disinfected, currentBlockInfo.nbt());
+    }
+
+    @Override
+    protected StructureProcessorType<?> getType() {
+        return ExterminatorModProcessors.DISINFECT;
+    }
+}

--- a/src/main/java/me/enchan/processors/DisinfectionProcessor.java
+++ b/src/main/java/me/enchan/processors/DisinfectionProcessor.java
@@ -2,6 +2,7 @@ package me.enchan.processors;
 
 import com.mojang.serialization.MapCodec;
 
+import me.enchan.ExterminatorMod;
 import net.minecraft.block.InfestedBlock;
 import net.minecraft.structure.StructurePlacementData;
 import net.minecraft.structure.StructureTemplate;
@@ -33,6 +34,12 @@ public class DisinfectionProcessor extends StructureProcessor {
 
         // 感染ブロックを通常ブロックに戻す
         var disinfected = ((InfestedBlock) block).toRegularState(state);
+        ExterminatorMod.Logger
+                .info("構造物消毒: 座標 %s の %s を %s に置き換えました".formatted(
+                        currentBlockInfo.pos().toShortString(),
+                        block.getName().getString(),
+                        disinfected.getBlock().getName().getString()));
+
         return new StructureTemplate.StructureBlockInfo(currentBlockInfo.pos(), disinfected, currentBlockInfo.nbt());
     }
 

--- a/src/main/java/me/enchan/processors/ExterminatorModProcessors.java
+++ b/src/main/java/me/enchan/processors/ExterminatorModProcessors.java
@@ -1,0 +1,28 @@
+package me.enchan.processors;
+
+import com.mojang.serialization.MapCodec;
+
+import me.enchan.ExterminatorMod;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.structure.processor.StructureProcessor;
+import net.minecraft.structure.processor.StructureProcessorType;
+import net.minecraft.util.Identifier;
+
+public class ExterminatorModProcessors {
+
+    public static final StructureProcessorType<DisinfectionProcessor> DISINFECT = register("disinfect",
+            DisinfectionProcessor.CODEC);
+
+    private static <P extends StructureProcessor> StructureProcessorType<P> register(
+            String id,
+            MapCodec<P> codec) {
+        return Registry.register(
+                Registries.STRUCTURE_PROCESSOR,
+                Identifier.of(ExterminatorMod.ModId, id),
+                () -> codec);
+    }
+
+    public static void initialize() {
+    }
+}

--- a/src/main/resources/exterminator.mixins.json
+++ b/src/main/resources/exterminator.mixins.json
@@ -8,7 +8,9 @@
 		"SilverfishEntityMixin",
 		"SpiderEntityMixin",
 		"CaveSpiderEntityMixin",
-		"IglooGeneratorPieceMixin"
+		"IglooGeneratorPieceMixin",
+		"WoodlandMansionGeneratorPieceMixin",
+		"FirstFloorRoomPoolMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1

--- a/src/main/resources/exterminator.mixins.json
+++ b/src/main/resources/exterminator.mixins.json
@@ -7,7 +7,8 @@
 		"PortalRoomMixin",
 		"SilverfishEntityMixin",
 		"SpiderEntityMixin",
-		"CaveSpiderEntityMixin"
+		"CaveSpiderEntityMixin",
+		"IglooGeneratorPieceMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
Fixes: #4

構造物の生成処理にmixinでインターセプトし、感染ブロックを消毒する処理を実装しました。

- **feat: #4 イグルーの生成処理をインターセプトして虫食いブロックを消毒する処理を実装**
- **chore: 消毒記録をログ出力**
- **feat: #4 偽エンドポータル部屋の生成を抑止した**
